### PR TITLE
feat: 統一前端功能頁面樣式與 icon

### DIFF
--- a/frontend/src/views/refund/bom/index.vue
+++ b/frontend/src/views/refund/bom/index.vue
@@ -1,16 +1,14 @@
 <template>
-  <div class="app-container">
-    <h2>Tax Refund BOM Management</h2>
-    <p>Coming Soon...</p>
-    <el-button type="primary">Example Button</el-button>
+  <div class="app-container" style="display: flex; height: calc(100vh - 84px); padding: 0;">
+    <!-- 待開發 -->
   </div>
 </template>
 
 <script setup>
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .app-container {
-    padding: 20px;
+  background-color: #f0f2f5;
 }
 </style>

--- a/frontend/src/views/refund/export/index.vue
+++ b/frontend/src/views/refund/export/index.vue
@@ -99,9 +99,9 @@
         </el-table-column>
         <el-table-column align="center" label="操作" width="180" fixed="right">
           <template #default="{ row }">
-            <el-button type="primary" size="small" :icon="Edit" @click="handleUpdate(row)" v-permission="['EXPORT_DECLARATION_EDIT']" />
+            <el-button type="warning" size="small" :icon="Edit" @click="handleUpdate(row)" circle v-permission="['EXPORT_DECLARATION_EDIT']" />
             <el-button type="danger" size="small" :icon="Delete" @click="handleDelete(row)"
-              :disabled="row.status !== 1" v-permission="['EXPORT_DECLARATION_EDIT']" />
+              :disabled="row.status !== 1" circle v-permission="['EXPORT_DECLARATION_EDIT']" />
           </template>
         </el-table-column>
       </el-table>
@@ -481,71 +481,71 @@ const confirmGenerateRefund = () => {
 }
 </script>
 
-<style scoped>
-.search-sidebar {
-  width: 250px;
+<style lang="scss" scoped>
+.app-container {
   background-color: #f0f2f5;
+}
+
+.search-sidebar {
+  width: 280px;
+  background-color: #fff;
   border-right: 1px solid #dcdfe6;
   display: flex;
   flex-direction: column;
+  padding: 10px;
   transition: width 0.3s;
-  flex-shrink: 0;
-}
-
-.search-header {
-  height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 15px;
-  background-color: #2d3a4b;
-  color: white;
-  font-weight: bold;
-}
-
-.collapse-btn {
-  cursor: pointer;
-  font-size: 18px;
-}
-
-.search-content {
-  flex: 1;
-  padding: 15px;
   overflow-y: auto;
+
+  .search-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    font-weight: bold;
+    font-size: 16px;
+
+    .collapse-btn {
+      cursor: pointer;
+      font-size: 20px;
+      &:hover { color: #409EFF; }
+    }
+  }
 }
 
-.search-actions {
-  margin-top: 20px;
-}
-
-/* 縮小後的側邊欄 */
 .search-sidebar-collapsed {
   width: 40px;
-  background-color: #2d3a4b;
-  color: white;
+  background-color: #fff;
+  border-right: 1px solid #dcdfe6;
   cursor: pointer;
   display: flex;
-  align-items: flex-start;
   justify-content: center;
-  padding-top: 15px;
+  padding-top: 20px;
   transition: width 0.3s;
-  flex-shrink: 0;
-}
 
-.collapsed-title {
-  writing-mode: vertical-rl;
-  letter-spacing: 5px;
-  display: flex;
-  align-items: center;
+  .collapsed-title {
+    writing-mode: vertical-lr;
+    letter-spacing: 5px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: bold;
+    color: #606266;
+  }
+
+  &:hover {
+    background-color: #f9fafc;
+    color: #409EFF;
+  }
 }
 
 .main-content {
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 10px;
-  overflow: hidden;
   background-color: #fff;
+  padding: 10px;
+  margin-left: 10px;
+  overflow: hidden;
 }
 
 .action-bar {
@@ -553,18 +553,16 @@ const confirmGenerateRefund = () => {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 15px;
-  padding: 10px;
-  background-color: #f5f7fa;
-  border-radius: 4px;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .pagination-container {
-  padding: 10px 0;
   display: flex;
   justify-content: flex-end;
+  padding: 10px 0;
 }
 
-/* Transition animation */
 .slide-fade-enter-active,
 .slide-fade-leave-active {
   transition: all 0.3s ease;

--- a/frontend/src/views/refund/list/index.vue
+++ b/frontend/src/views/refund/list/index.vue
@@ -42,20 +42,21 @@
 
     <!-- 右側內容區 -->
     <div class="main-content">
-        <!-- 標題與操作區 -->
-        <div class="action-bar">
-            <h3>退稅清單管理</h3>
-            <div>
-              <el-button type="success" :icon="Download" @click="handleExportL(null)" 
-                v-permission="['TAX_REFUND_VIEW']" :disabled="!isSingleSelection || multipleSelection[0].status < 2">用料清表(L)</el-button>
-              <el-button type="warning" :icon="Download" @click="handleExportA(null)" 
-                v-permission="['TAX_REFUND_VIEW']" :disabled="!isSingleSelection || multipleSelection[0].status < 2">沖退稅申請(A)</el-button>
-            </div>
+      <div class="action-bar">
+        <div class="left-panel">
+          <!-- 可放標題或麵包屑 -->
         </div>
+        <div class="right-panel">
+          <el-button type="success" :icon="Download" @click="handleExportL(null)"
+            v-permission="['TAX_REFUND_VIEW']" :disabled="!isSingleSelection || multipleSelection[0].status < 2">用料清表(L)</el-button>
+          <el-button type="warning" :icon="Download" @click="handleExportA(null)"
+            v-permission="['TAX_REFUND_VIEW']" :disabled="!isSingleSelection || multipleSelection[0].status < 2">沖退稅申請(A)</el-button>
+        </div>
+      </div>
 
       <!-- 資料表格 -->
       <el-table ref="tableRef" v-loading="listLoading" :data="list" element-loading-text="載入中" border fit
-        highlight-current-row height="calc(100% - 60px)" style="width: 100%;"
+        highlight-current-row height="calc(100% - 90px)" style="width: 100%;"
         :header-cell-style="{ background: '#2d3a4b', color: '#ffffff', fontWeight: 'bold' }"
         @selection-change="handleSelectionChange">
         
@@ -82,8 +83,8 @@
         </el-table-column>
         <el-table-column align="center" label="操作" width="120" fixed="right">
           <template #default="{ row }">
-            <el-button type="primary" size="small" :icon="Edit" @click="handleEditRefund(row)" 
-                v-permission="['EXPORT_DECLARATION_EDIT']" :disabled="row.status < 2">修改退稅</el-button>
+            <el-button type="warning" size="small" :icon="Edit" @click="handleEditRefund(row)"
+                circle v-permission="['EXPORT_DECLARATION_EDIT']" :disabled="row.status < 2" />
           </template>
         </el-table-column>
       </el-table>
@@ -307,71 +308,71 @@ const handleRefundQtyChange = (row) => {
 
 </script>
 
-<style scoped>
-.search-sidebar {
-  width: 250px;
+<style lang="scss" scoped>
+.app-container {
   background-color: #f0f2f5;
+}
+
+.search-sidebar {
+  width: 280px;
+  background-color: #fff;
   border-right: 1px solid #dcdfe6;
   display: flex;
   flex-direction: column;
+  padding: 10px;
   transition: width 0.3s;
-  flex-shrink: 0;
-}
-
-.search-header {
-  height: 50px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 15px;
-  background-color: #2d3a4b;
-  color: white;
-  font-weight: bold;
-}
-
-.collapse-btn {
-  cursor: pointer;
-  font-size: 18px;
-}
-
-.search-content {
-  flex: 1;
-  padding: 15px;
   overflow-y: auto;
+
+  .search-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    font-weight: bold;
+    font-size: 16px;
+
+    .collapse-btn {
+      cursor: pointer;
+      font-size: 20px;
+      &:hover { color: #409EFF; }
+    }
+  }
 }
 
-.search-actions {
-  margin-top: 20px;
-}
-
-/* 縮小後的側邊欄 */
 .search-sidebar-collapsed {
   width: 40px;
-  background-color: #2d3a4b;
-  color: white;
+  background-color: #fff;
+  border-right: 1px solid #dcdfe6;
   cursor: pointer;
   display: flex;
-  align-items: flex-start;
   justify-content: center;
-  padding-top: 15px;
+  padding-top: 20px;
   transition: width 0.3s;
-  flex-shrink: 0;
-}
 
-.collapsed-title {
-  writing-mode: vertical-rl;
-  letter-spacing: 5px;
-  display: flex;
-  align-items: center;
+  .collapsed-title {
+    writing-mode: vertical-lr;
+    letter-spacing: 5px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: bold;
+    color: #606266;
+  }
+
+  &:hover {
+    background-color: #f9fafc;
+    color: #409EFF;
+  }
 }
 
 .main-content {
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 10px;
-  overflow: hidden;
   background-color: #fff;
+  padding: 10px;
+  margin-left: 10px;
+  overflow: hidden;
 }
 
 .action-bar {
@@ -379,16 +380,24 @@ const handleRefundQtyChange = (row) => {
   justify-content: space-between;
   align-items: center;
   margin-bottom: 15px;
-  padding: 0 10px;
-  background-color: #f5f7fa;
-  border-radius: 4px;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .pagination-container {
-  padding: 10px 0;
   display: flex;
   justify-content: flex-end;
+  padding: 10px 0;
 }
 
-/* Base styles for tables/forms if needed */
+.slide-fade-enter-active,
+.slide-fade-leave-active {
+  transition: all 0.3s ease;
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+  transform: translateX(-20px);
+  opacity: 0;
+}
 </style>


### PR DESCRIPTION
## 關聯 Issue
Closes #2

## 變更摘要
- 側邊欄：灰底深色 header → 全白 280px，移除深色 header
- 收合側邊欄：深色背景白字 → 白底灰字，hover 藍色提示
- action-bar：灰底 padding → 無背景，flex-wrap + gap 彈性排版
- 主內容區：補上 `margin-left: 10px`
- 表格操作按鈕：統一改為 `circle` 圓形，Edit 按鈕改為 `warning` 橙色
- 退稅清單 action-bar 結構對齊（left-panel / right-panel），移除 `<h3>` 標題
- 表格高度修正：`calc(100% - 60px)` → `calc(100% - 90px)`
- 樣式語言：純 CSS → SCSS

## 測試方式
- [ ] 瀏覽器開啟各頁面，確認側邊欄白底、無深色 header
- [ ] 點擊收合按鈕，確認白底灰字顯示
- [ ] 確認表格操作按鈕為圓形 icon
- [ ] 確認 action-bar 無灰色背景